### PR TITLE
Added support for OPNsense cron logs

### DIFF
--- a/default/props.conf
+++ b/default/props.conf
@@ -14,7 +14,7 @@ KV_MODE         = none
 # This is to help the sourcetyper extract the sourcetype properly
 #===========================================
 SEDCMD-0opnsense_squid_cleaner  = s/(\(squid\S+)/squid:/g
-TRANSFORMS-opnsense_change_sourcetype = opnsense_sourcetype_filterlog,opnsense_sourcetype_dhcpd,opnsense_sourcetype_suricata,opnsense_sourcetype_squid
+TRANSFORMS-opnsense_change_sourcetype = opnsense_sourcetype_filterlog,opnsense_sourcetype_dhcpd,opnsense_sourcetype_suricata,opnsense_sourcetype_squid,opnsense_sourcetype_cron
 
 [opnsense:filterlog]
 ANNOTATE_PUNCT                           = false
@@ -90,3 +90,8 @@ EVAL-src_ip                   = if(src_ip=="-", null(), src_ip)
 FIELDALIAS-opnsense_squid_src = src_ip AS src
 LOOKUP-opnsense_squid_action  = opnsense_squid_action_lookup vendor_action OUTPUTNEW action
 LOOKUP-opnsense_squid_status  = opnsense_squid_status_lookup status OUTPUTNEW status_description
+
+[opnsense:cron]
+ANNOTATE_PUNCT                = false
+KV_MODE                       = false
+REPORT-opnsense_cron_main    = opnsense_cron_main

--- a/default/transforms.conf
+++ b/default/transforms.conf
@@ -26,6 +26,11 @@ DEST_KEY = MetaData:Sourcetype
 REGEX    = suricata\S+\:\s
 FORMAT   = sourcetype::opnsense:suricata
 
+[opnsense_sourcetype_cron]
+DEST_KEY = MetaData:Sourcetype
+REGEX    = cron\[\d+\]
+FORMAT   = sourcetype::opnsense:cron
+
 #===========================================
 # Search Time Field Extractions:  GLOBAL
 #===========================================
@@ -137,6 +142,13 @@ FORMAT = duration::$1 src_ip::$2 vendor_action::$3 status::$4 bytes_in::$5 bytes
 SOURCE_KEY = url
 REGEX = (\d{1,3}(?:\.\d{1,3}){3})
 FORMAT = dest_ip_url::$1
+
+#===========================================
+# Search Time Field Extractions:  CRON
+#===========================================
+[opnsense_cron_main]
+REGEX  = \((\w+)\) CMD \(\(?(.+?)\)?(?: > (.+?))?\)
+FORMAT = user::$1 command::$2 output::$3
 
 #===========================================
 # Advanced Search Time Configs


### PR DESCRIPTION
There's no CIM for cron jobs, so this just provides search-time field extractions for the user, command, and output fields.