### PR TITLE
Add parsing for unbound log

### DIFF
--- a/default/props.conf
+++ b/default/props.conf
@@ -14,7 +14,7 @@ KV_MODE         = none
 # This is to help the sourcetyper extract the sourcetype properly
 #===========================================
 SEDCMD-0opnsense_squid_cleaner  = s/(\(squid\S+)/squid:/g
-TRANSFORMS-opnsense_change_sourcetype = opnsense_sourcetype_filterlog,opnsense_sourcetype_dhcpd,opnsense_sourcetype_suricata,opnsense_sourcetype_squid,opnsense_sourcetype_cron
+TRANSFORMS-opnsense_change_sourcetype = opnsense_sourcetype_filterlog,opnsense_sourcetype_dhcpd,opnsense_sourcetype_suricata,opnsense_sourcetype_squid,opnsense_sourcetype_cron,opnsense_sourcetype_unbound
 
 [opnsense:filterlog]
 ANNOTATE_PUNCT                           = false
@@ -95,3 +95,8 @@ LOOKUP-opnsense_squid_status  = opnsense_squid_status_lookup status OUTPUTNEW st
 ANNOTATE_PUNCT                = false
 KV_MODE                       = false
 REPORT-opnsense_cron_main    = opnsense_cron_main
+
+[opnsense:unbound]
+KV_MODE = false
+ANNOTATE_PUNCT = false
+REPORT-opnsense_unbound_query = opnsense_unbound_query

--- a/default/transforms.conf
+++ b/default/transforms.conf
@@ -31,6 +31,11 @@ DEST_KEY = MetaData:Sourcetype
 REGEX    = cron\[\d+\]
 FORMAT   = sourcetype::opnsense:cron
 
+[opnsense_sourcetype_unbound]
+DEST_KEY = MetaData:Sourcetype
+REGEX    = unbound\:
+FORMAT   = sourcetype::opnsense:unbound
+
 #===========================================
 # Search Time Field Extractions:  GLOBAL
 #===========================================
@@ -149,6 +154,13 @@ FORMAT = dest_ip_url::$1
 [opnsense_cron_main]
 REGEX  = \((\w+)\) CMD \(\(?(.+?)\)?(?: > (.+?))?\)
 FORMAT = user::$1 command::$2 output::$3
+
+#===========================================
+# Search Time Field Extractions:  UNBOUND
+#===========================================
+[opnsense_unbound_query]
+REGEX = info:\s+(\S+)\s+(\S+)\s+(\S+)
+FORMAT = client::$1 query::$2 record_type::$3
 
 #===========================================
 # Advanced Search Time Configs


### PR DESCRIPTION
If you add "log-queries: yes" in the custom options of unbound, you can log the DNS queries

This patch add the parsing for these logs