### PR TITLE
New OPNSense VPN Logging format

### DIFF
--- a/src/TA-opnsense/default/transforms.conf
+++ b/src/TA-opnsense/default/transforms.conf
@@ -52,7 +52,7 @@ FORMAT   = sourcetype::opnsense:lighttpd
 
 [opnsense_sourcetype_openvpn]
 DEST_KEY = MetaData:Sourcetype
-REGEX    = openvpn(?:\[[^\]]+\]):*
+REGEX    = openvpn\w*(?:\[[^\]]+\]):*
 FORMAT   = sourcetype::opnsense:openvpn
 
 [opnsense_sourcetype_squid]
@@ -200,10 +200,10 @@ FORMAT = user::$1 auth_method::$2
 REGEX = ifconfig\s+(?<dest_ip>\S+)
 
 [opnsense_openvpn_extract]
-REGEX = openvpn\[(?<pid>[^\]]+)\]:\s+(?<user>[^\/]+)\/(?<src_ip>[^:]+):(?<src_port>\d+)
+REGEX = openvpn(?:_(?<vpn_instance>[^\[\:]+))?(?:\[(?<pid>[^\]]+)\])?:\s+(?<user>[^\/]+)\/(?<src_ip>[^:]+):(?<src_port>\d+)
 
 [opnsense_openvpn_src]
-REGEX  = openvpn(?:\[([^\]]+)\]):*\s(?<src_ip>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\:(?<src_port>\d+)\s
+REGEX  = openvpn(?:_(?<vpn_instance>[^\[\:]+))?(?:\[(?<pid>[^\]]+)\])?:*\s(?<src_ip>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\:(?<src_port>\d+)\s
 
 #===========================================
 # Search Time Field Extractions:  SURICATA


### PR DESCRIPTION
OPNSense changed the logging format for Openvpn.
now the VPN instance name ( useful if multiple Openvpn servers are used )  is included in the name.

new format example:
`openvpn_server2[68460]: user/ip:1651`

changed regex, so it is compatible with the old and new format.
(now instance and PID number are optional)